### PR TITLE
MArked feature variables as extern

### DIFF
--- a/picosat.c
+++ b/picosat.c
@@ -31,6 +31,16 @@ IN THE SOFTWARE.
 
 #include "picosat.h"
 
+/* Initialization of global feature variables */
+enum Phase GLOBAL_DEFAULT_PHASE = 0;
+int ALLSAT = 0;
+int PARTIAL = 0;
+int PLAIN = 0;
+const char * COMPACT_TRACE_NAME = 0;
+const char * EXTENDED_TRACE_NAME = 0;
+const char * RUP_TRACE_NAME = 0;
+FILE * INCREMENTAL_RUP_FILE = 0;
+
 /* By default code for 'all different constraints' is disabled, since 'NADC'
  * is defined.
  */

--- a/picosat.h
+++ b/picosat.h
@@ -60,14 +60,14 @@ enum Phase
  RNDPHASE,
 };
 
-static __attribute__((feature_variable("DefaultPhase"))) enum Phase GLOBAL_DEFAULT_PHASE = 0;
-static __attribute__((feature_variable("AllSat"))) int ALLSAT = 0;
-static int PARTIAL = 0;
-static __attribute__((feature_variable("Plain"))) int PLAIN = 0;
-static __attribute__((feature_variable("CompactTrace"))) const char * COMPACT_TRACE_NAME = 0;
-static __attribute__((feature_variable("ExtendedTrace"))) const char * EXTENDED_TRACE_NAME = 0;
-static __attribute__((feature_variable("RUPTrace"))) const char * RUP_TRACE_NAME = 0;
-static FILE * INCREMENTAL_RUP_FILE = 0;
+extern __attribute__((feature_variable("DefaultPhase"))) enum Phase GLOBAL_DEFAULT_PHASE;
+extern __attribute__((feature_variable("AllSat"))) int ALLSAT;
+extern int PARTIAL;
+extern __attribute__((feature_variable("Plain"))) int PLAIN;
+extern __attribute__((feature_variable("CompactTrace"))) const char * COMPACT_TRACE_NAME;
+extern __attribute__((feature_variable("ExtendedTrace"))) const char * EXTENDED_TRACE_NAME;
+extern __attribute__((feature_variable("RUPTrace"))) const char * RUP_TRACE_NAME;
+extern FILE * INCREMENTAL_RUP_FILE;
 
 /*------------------------------------------------------------------------*/
 


### PR DESCRIPTION
Previously, they were static variables which was not right due to usage in different compilation units.